### PR TITLE
Aligned developer views following CDN CSS updates to accordions which affected tabs

### DIFF
--- a/DFC.App.Pages/Views/Shared/_GovUkHeader.cshtml
+++ b/DFC.App.Pages/Views/Shared/_GovUkHeader.cshtml
@@ -1,4 +1,5 @@
-﻿<header class="govuk-header " role="banner" data-module="govuk-header">
+﻿<partial name="_jsEnabled" />
+<header class="govuk-header " role="banner" data-module="govuk-header">
     <div class="govuk-header__container govuk-width-container">
         <a href="/" class="govuk-header__link govuk-header__link--service-name">
             National Careers Service

--- a/DFC.App.Pages/Views/Shared/_LocalCss.cshtml
+++ b/DFC.App.Pages/Views/Shared/_LocalCss.cshtml
@@ -1,10 +1,6 @@
 ﻿@{
     var cdnLocation = "https://dev-cdn.nationalcareersservice.org.uk/nationalcareers_toolkit";
+    var queryStringVersion = @DateTime.Today.ToString("yyyy-mm-dd");
 }
 
-<link href="@cdnLocation/css/all.min.css" rel="stylesheet" type="text/css" />
-
-@*<link href="~/css/dfc-composite-shell.css" rel="stylesheet" type="text/css" asp-append-version="true" />
-    <link href="~/css/dfc-app-pages.css" rel="stylesheet" type="text/css" asp-append-version="true" />*@
-
-@*<link href="~/css/experimental.css" rel="stylesheet" type="text/css" asp-append-version="true" />*@
+<link href="@cdnLocation/css/all.min.css?@queryStringVersion" rel="stylesheet" type="text/css" />

--- a/DFC.App.Pages/Views/Shared/_LocalJs.cshtml
+++ b/DFC.App.Pages/Views/Shared/_LocalJs.cshtml
@@ -1,16 +1,10 @@
 ﻿@{
     var cdnLocation = "https://dev-cdn.nationalcareersservice.org.uk/nationalcareers_toolkit";
+    var queryStringVersion = @DateTime.Today.ToString("yyyy-mm-dd");
 }
 
-<script src="@cdnLocation/js/jquerybundle.min.js"></script>
-<script src="@cdnLocation/js/all.min.js"></script>
+<script src="@cdnLocation/js/jquerybundle.min.js?@queryStringVersion"></script>
+<script src="@cdnLocation/js/all.min.js?@queryStringVersion"></script>
+<script src="@cdnLocation/js/dfcdigital.min.js?@queryStringVersion"></script>
 
 <script>window.GOVUKFrontend.initAll()</script>
-
-<script src="@cdnLocation/js/dfcdigital.min.js"></script>
-<script src="@cdnLocation/js/compui.min.js"></script>
-
-@*<script src="~/js/compui-utilities.js" asp-append-version="true"></script>
-    <script src="~/js/compui-validation.js" asp-append-version="true"></script>
-    <script src="~/js/apps/dfc-app-pages.js "asp-append-version="true"></script>
-    <script src="~/js/compui-shell.js" asp-append-version="true"></script>*@

--- a/DFC.App.Pages/Views/Shared/_jsEnabled.cshtml
+++ b/DFC.App.Pages/Views/Shared/_jsEnabled.cshtml
@@ -1,0 +1,3 @@
+﻿<script>
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+</script>


### PR DESCRIPTION
Added missing js-enabled class to layout's page BODY to align with the Shell